### PR TITLE
Fix apostrophe capitalization

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 const lowerCase = require('./lower-case')
 const specials = require('./specials')
 
-const regex = /(?:(?:((?:^|[.!?;:"-])\s*)(\w))|(\w))(\w*)/g
+const regex = /(?:(?:((?:^|[.!?;:"-])\s*)(\w))|(\w))(\w*[’']*\w*)/g
 
 const convertToRegExp = specials => specials.map(s => [new RegExp(`\\b${s}\\b`, 'gi'), s])
 

--- a/test/index.js
+++ b/test/index.js
@@ -56,3 +56,10 @@ test(t => {
     special: ['facebook', 'Microsoft']
   }), to)
 })
+
+test(t => {
+  const from = "seattle’S BEST coffee & grandma's cookies"
+  const to = "Seattle’s Best Coffee & Grandma's Cookies"
+
+  t.is(title(from), to)
+})


### PR DESCRIPTION
This fixes the bug where it turned `dog's ear` into `Dog'S ear`