### PR TITLE
Added -s alias for --special

### DIFF
--- a/bin/title.js
+++ b/bin/title.js
@@ -18,7 +18,8 @@ const { _, ...args } = parse({
   '--special': [String],
   '-v': '--version',
   '-h': '--help',
-  '-n': '--no-copy'
+  '-n': '--no-copy',
+  '-s': '--special'
 })
 
 // Output the package's version if


### PR DESCRIPTION
Even though the `-s` alias is logged out in the help, `-s` does not work.

This commit fixes that.