### PR TITLE
Handle adjacent parentheses (fixes #9)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,17 +2,37 @@
 const lowerCase = require('./lower-case')
 const specials = require('./specials')
 
-const regex = /(?:(?:((?:^|[.!?;:"-])\s*)(\w))|(\w))(\w*[’']*\w*)/g
+const regex = /(?:(?:(\s?(?:^|[.\(\)!?;:"-])\s*)(\w))|(\w))(\w*[’']*\w*)/g
 
 const convertToRegExp = specials => specials.map(s => [new RegExp(`\\b${s}\\b`, 'gi'), s])
 
+function parseMatch(match) {
+  const firstCharacter = match[0]
+
+  // test first character
+  if (/\s/.test(match[0])) {
+    // if whitespace - trim and return
+    return match.substr(1)
+  }
+  if (/[\(\)]/.test(match[0])) {
+    // if parens - this shouldn't be replaced
+    return null
+  }
+
+  return match
+}
+
 module.exports = (str, options = {}) => {
   str = str.toLowerCase().replace(regex, (m, lead = '', forced, lower, rest) => {
+    const parsedMatch = parseMatch(m)
+    if (!parsedMatch) {
+      return m
+    }
     if (!forced) {
       const fullLower = lower + rest
 
       if (lowerCase.has(fullLower)) {
-        return m
+        return parsedMatch
       }
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -63,3 +63,10 @@ test(t => {
 
   t.is(title(from), to)
 })
+
+test('should not capitalize word in adjacent parens', t => {
+  const from = "employment region(s) for my application"
+  const to = "Employment Region(s) for My Application"
+
+  t.is(title(from), to)
+})

--- a/test/index.js
+++ b/test/index.js
@@ -64,9 +64,16 @@ test(t => {
   t.is(title(from), to)
 })
 
-test('should not capitalize word in adjacent parens', t => {
-  const from = "employment region(s) for my application"
-  const to = "Employment Region(s) for My Application"
+test("should not capitalize word in adjacent parens", t => {
+  let from = "employment region(s) for my application"
+  let to = "Employment Region(s) for My Application"
+  t.is(title(from), to)
 
+  from = "(s)omething or other"
+  to = "(s)omething or Other"
+  t.is(title(from), to)
+
+  from = "cat(s) can be a pain"
+  to = "Cat(s) can Be a Pain"
   t.is(title(from), to)
 })


### PR DESCRIPTION
Words in adjacent parentheses shouldn't be replaced anymore.

i.e. _employment region(s) for my application_ -> _Employment Region(s) for My Application_